### PR TITLE
Fixed extra v-scrolling in landing page for mobile devices

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -8,7 +8,7 @@ const LandingPage = () => {
       // Here use .container-fluid instead of .container because .container has one fixed width for each screen size in bootstrap (xs,sm,md,lg,xl,xxl); .container-fluid expands to fill the available width.
       className='d-flex container-fluid'
       style={{
-        minHeight: '100vh',
+        minHeight: '90vh',
         justifyContent: 'center',
       }}
     >


### PR DESCRIPTION
Fixed extra scrolling in Landing page.

**Issue Reason**
`minHeight` property was set as `100vh` in the `LandingPage` component, while the NavBar also needed some space. Thus the scroll was appearing to accommodate the extra space.

**Issue Fix**
Make the `LandingPage` component `minHeight` property to `90vh`.